### PR TITLE
DACCESS-207: Update request_item for Poppy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The wrapped methods include:
 
 Most of the methods are centered around the needs of discovery systems to retrieve patron account details and to request library materials.
 
-Version 2.0.1 and higher of CUL::FOLIO::Edge requires FOLIO's Poppy release or above -- more specificially, `mod-circulation` v. 24.0 or higher.
+Version 3.0 and higher of CUL::FOLIO::Edge requires FOLIO's Poppy release or above -- more specificially, `mod-circulation` v. 24.0 or higher.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,25 @@
-# Cul::Folio::Edge
+# CUL::FOLIO::Edge
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/cul/folio/edge`. To experiment with that code, run `bin/console` for an interactive prompt.
+CUL::FOLIO::Edge is a Ruby wrapper for several [FOLIO](https://folio.org) APIs, originally developed for use with [Cornell University Library](https://library.cornell.edu)'s [Blacklight](https://projectblacklight.org) catalog.
 
-TODO: Delete this and the text above, and describe your gem
+The wrapped methods include:
+
+| method | FOLIO API endpoint |
+| ------ | ----- |
+| authenticate | /authn/login |
+| patron_record | /users |
+| patron_account | /patron/account |
+| renew_item | /patron/account |
+| request_options | /circulation/rules/request-policy |
+| | /request-policy-storage/request-policies |
+| instance_record | /inventory/instances |
+| request_item | /circulation/requests |
+| cancel_request | /circulation/requests |
+| service_point | /service-points |
+
+Most of the methods are centered around the needs of discovery systems to retrieve patron account details and to request library materials.
+
+Version 2.0.1 and higher of CUL::FOLIO::Edge requires FOLIO's Poppy release or above -- more specificially, `mod-circulation` v. 24.0 or higher.
 
 ## Installation
 

--- a/lib/cul/folio/edge.rb
+++ b/lib/cul/folio/edge.rb
@@ -329,7 +329,7 @@ module CUL
         # +requesterId+:: UUID of the requester
         # +requestType+:: Hold, Recall, or Page
         # +requestDate+:: String date of the request (e.g., "2017-07-29T22:25:37Z")
-        # +fulfilmentPreference+:: 'Hold Shelf' or 'Delivery'
+        # +fulfillmentPreference+:: 'Hold Shelf' or 'Delivery'
         # +servicePointId+:: UUID of the pickup service point
         # +comments+:: Patron comments (optional)
         # +requestLevel+:: 'Item' (optional, added now for future-proofing; eventually there will be another choice for title-level requests)
@@ -339,7 +339,7 @@ module CUL
         # +:code+:: An HTTP response code
         # +:error+:: An error message, or nil
         ##
-        def self.request_item(okapi, tenant, token, instanceId, holdingsId, itemId, requesterId, requestType, requestDate, fulfilmentPreference, servicePointId, comments = '', requestLevel = 'Item')
+        def self.request_item(okapi, tenant, token, instanceId, holdingsId, itemId, requesterId, requestType, requestDate, fulfillmentPreference, servicePointId, comments = '', requestLevel = 'Item')
           url = "#{okapi}/circulation/requests"
           headers = {
             'X-Okapi-Tenant' => tenant,
@@ -355,7 +355,7 @@ module CUL
             'requestType' => requestType,
             'requestDate' => requestDate,
             'requestLevel' => requestLevel,
-            'fulfilmentPreference' => fulfilmentPreference,
+            'fulfillmentPreference' => fulfillmentPreference,
             'pickupServicePointId' => servicePointId,
           }
 

--- a/lib/cul/folio/edge/version.rb
+++ b/lib/cul/folio/edge/version.rb
@@ -1,7 +1,7 @@
 module Cul
   module Folio
     module Edge
-      VERSION = "3.0"
+      VERSION = "2.0.1"
     end
   end
 end

--- a/lib/cul/folio/edge/version.rb
+++ b/lib/cul/folio/edge/version.rb
@@ -1,7 +1,7 @@
 module Cul
   module Folio
     module Edge
-      VERSION = "2.0.0"
+      VERSION = "3.0"
     end
   end
 end

--- a/lib/cul/folio/edge/version.rb
+++ b/lib/cul/folio/edge/version.rb
@@ -1,7 +1,7 @@
 module Cul
   module Folio
     module Edge
-      VERSION = "2.0.1"
+      VERSION = "3.0"
     end
   end
 end

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,6 +1,6 @@
 # Release Notes - cul-folio-edge
 
-## 2.0.1
+## 3.0
 - Update the `request_item` method for FOLIO Poppy change to spelling of `fulfillmentPreference` (DACCESS-207)
 - Add basic test setup using RSpec, VCR, and initial tests (cf. DACCESS-97)
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,6 +1,6 @@
 # Release Notes - cul-folio-edge
 
-## 3.0
+## 2.0.1
 - Update the `request_item` method for FOLIO Poppy change to spelling of `fulfillmentPreference` (DACCESS-207)
 - Add basic test setup using RSpec, VCR, and initial tests (cf. DACCESS-97)
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,7 +1,8 @@
 # Release Notes - cul-folio-edge
 
-## In progress
-- Add RSpec tests
+## 3.0
+- Update the `request_item` method for FOLIO Poppy change to spelling of `fulfillmentPreference` (DACCESS-207)
+- Add basic test setup using RSpec, VCR, and initial tests (cf. DACCESS-97)
 
 ## 2.0
 - Modify the `request_item` method to add new required parameters for FOLIO Lotus (DISCOVERYACCESS-7496)

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,6 +3,7 @@
 ## 3.0
 - Update the `request_item` method for FOLIO Poppy change to spelling of `fulfillmentPreference` (DACCESS-207)
 - Add basic test setup using RSpec, VCR, and initial tests (cf. DACCESS-97)
+- Update README
 
 ## 2.0
 - Modify the `request_item` method to add new required parameters for FOLIO Lotus (DISCOVERYACCESS-7496)


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/DACCESS-207

This updates the `request_item` method to handle breaking changes to the API we're calling in Poppy. ~~Since this is a breaking change for our library, this bumps the version number to 3.0.~~ I'm going to hold off on merging the PR until next week, when I can think a little more about any unintended consequences (since we don't have the Gemfile references to cul-folio-edge pinned/set consistently in Requests, My Account, and Blacklight).

I've also finally gotten around to adding a bit of relevant text to the boilerplate README. After all these years!